### PR TITLE
make the code python>=3.12.0 compatible and general code improvements

### DIFF
--- a/lib/core_tools/contracts.py
+++ b/lib/core_tools/contracts.py
@@ -1,8 +1,10 @@
-from .tools import *
+import web3
+from web3 import types
+from lib.core_tools import tools
 
 
 class Competition:
-    def __init__(self, json_interface: json, w3: web3.Web3, address: types.ChecksumAddress, controlling_account=None, verbose=True):
+    def __init__(self, json_interface: dict, w3: web3.Web3, address: types.ChecksumAddress, controlling_account=None, verbose=True):
         abi = json_interface['abi']
         contract = w3.eth.contract(abi=abi)
         self._w3 = w3
@@ -35,13 +37,13 @@ class Competition:
 
     def getStakeThreshold(self):
         return self._contract.functions.getStakeThreshold().call()
-    
+
     def getSubmission(self, challenge_number, participant):
         return self._contract.functions.getSubmission(challenge_number, participant).call()
 
 
 class Token:
-    def __init__(self, json_interface: json, w3: web3.Web3, address: types.ChecksumAddress, controlling_account=None, verbose=True):
+    def __init__(self, json_interface: dict, w3: web3.Web3, address: types.ChecksumAddress, controlling_account=None, verbose=True):
         abi = json_interface['abi']
         contract = w3.eth.contract(abi=abi)
         self._w3 = w3
@@ -67,11 +69,10 @@ class Token:
     def balanceOf(self, account):
         return self._contract.functions.balanceOf(account).call()
 
-    def stakeAndSubmit(self, target: str, amount_token: int, submission_hash: str or bytes, gas_price_in_wei: int):
-        return send_transaction(self._w3,
+    def stakeAndSubmit(self, target: str, amount_token: int, submission_hash: str | bytes, gas_price_in_wei: int):
+        return tools.send_transaction(self._w3,
                                 self._controlling_account,
                                 self._contract.functions.stakeAndSubmit,
                                 [target, amount_token, submission_hash],
                                 gas_price_in_wei
                                 )
-

--- a/lib/core_tools/tools.py
+++ b/lib/core_tools/tools.py
@@ -49,7 +49,7 @@ class GasPriceMode:
 
 def cid_to_hash(cid: str) -> str:
     res = base58.b58decode(cid).hex()
-    return res[-4:].encode("utf8")
+    return res[-32:].encode("utf8")
 
 
 def decimal_to_uint(decimal_value: Decimal | float | int, decimal_places=6) -> int:
@@ -173,10 +173,11 @@ def pin_file_to_ipfs(filename: str, jwt: str, cid_version=0, verbose=False, retr
                 files = {"file": f}
                 params = {"cidVersion": cid_version}
                 response = requests.post(url, headers=headers, files=files, params=params)
+                response_json = response.json()
                 if verbose:
                     print('Pinned payload with size {} bytes to {} at {}.'.format(
-                        response['PinSize'], response['IpfsHash'], response['Timestamp']))
-                return response.json()['IpfsHash']
+                        response_json['PinSize'], response_json['IpfsHash'], response_json['Timestamp']))
+                return response_json['IpfsHash']
         except Exception as e:
             if tries == num_retries - 1:
                 assert False, 'File could not be uploaded and pinned to IPFS. Please try again later or contact {} for support.'.format(

--- a/lib/core_tools/tools.py
+++ b/lib/core_tools/tools.py
@@ -49,7 +49,7 @@ class GasPriceMode:
 
 def cid_to_hash(cid: str) -> str:
     res = base58.b58decode(cid).hex()
-    return res[-32:].encode("utf8")
+    return res[4:]
 
 
 def decimal_to_uint(decimal_value: Decimal | float | int, decimal_places=6) -> int:

--- a/lib/submitter.py
+++ b/lib/submitter.py
@@ -1,36 +1,48 @@
-from .core_tools.contracts import *
+import json
+import os
+import shutil
+from decimal import Decimal
+
+import pandas as pd
+import web3
+from Crypto.PublicKey import RSA
+
+from lib.core_tools import contracts
+from lib.core_tools import tools
 
 
 class Submitter:
-    def __init__(self, jwt: str, address: str, comp_params: CompetitionParams, private_key=None, url=CFG['RPC_GATEWAY']):
+    def __init__(self, jwt: str, address: str,
+                 comp_params: tools.CompetitionParams,
+                 private_key=None, url=tools.CFG['RPC_GATEWAY']):
         self._w3 = web3.Web3(
             web3.Web3.HTTPProvider(
                 url,
-                request_kwargs={'timeout': CFG['W3_TIMEOUT']}
+                request_kwargs={'timeout': tools.CFG['W3_TIMEOUT']}
             )
         )
         self._jwt = jwt
-        self._address = self._w3.toChecksumAddress(address)
+        self._address = self._w3.to_checksum_address(address)
         self._private_key = private_key
         self._comp_params = comp_params
         if private_key is not None:
             self._controlling_account = self._w3.eth.account.from_key(self._private_key)
 
-            # Sanity check on controlling address.
+            # Sanity check on con          rolling address.
             assert self._controlling_account.address == self._address, 'Private key does not match address {}.'.format(
                 self._address)
         else:
             self._controlling_account = None
 
         # Load Token interface.
-        with open('{}//{}//Token.json'.format(CURRENT_DIR, CFG['JSON_DIRECTORY'])) as f:
+        with open('{}//{}//Token.json'.format(tools.CURRENT_DIR, tools.CFG['JSON_DIRECTORY'])) as f:
             token_json = json.load(f)
-        self._token = Token(token_json, self._w3, TOKEN_ADDRESS, self._controlling_account)
+        self._token = contracts.Token(token_json, self._w3, tools.TOKEN_ADDRESS, self._controlling_account)
 
         # Load Competition interface.
-        with open('{}//{}//Competition.json'.format(CURRENT_DIR, CFG['JSON_DIRECTORY'])) as f:
+        with open('{}//{}//Competition.json'.format(tools.CURRENT_DIR, tools.CFG['JSON_DIRECTORY'])) as f:
             competition_json = json.load(f)
-        self._competition = Competition(competition_json, self._w3, self._comp_params.address, self._controlling_account)
+        self._competition = contracts.Competition(competition_json, self._w3, self._comp_params.address, self._controlling_account)
 
     @property
     def address(self):
@@ -50,33 +62,33 @@ class Submitter:
         """
         @returns: Amount of YIEDL in Submitter's wallet.
         """
-        return uint_to_decimal(self._token.balanceOf(self._address))
+        return tools.uint_to_decimal(self._token.balanceOf(self._address))
 
     def get_matic_balance(self) -> Decimal:
         """
         @returns: Amount of MATIC in Submitter's wallet.
         """
-        return uint_to_decimal(self._w3.eth.get_balance(self._address))
+        return tools.uint_to_decimal(self._w3.eth.get_balance(self._address))
 
     def get_stake(self) -> Decimal:
         """
         @returns: Amount of YIEDL staked by Submitter in the Competition.
         """
-        return uint_to_decimal(self._competition.getStake(self._address))
+        return tools.uint_to_decimal(self._competition.getStake(self._address))
 
     def get_stake_threshold(self) -> Decimal:
         """
         @returns: Minimum YIEDL required for staking.
         """
-        return uint_to_decimal(self._competition.getStakeThreshold())
+        return tools.uint_to_decimal(self._competition.getStakeThreshold())
 
     def get_submission_cid(self, challenge_number) -> str or None:
         """
         @params: challenge_number: Challenge to return Submitter's submission cid of.
         @returns: IPFS Content Identifier (CID) of Submitter's existing submission. Returns None if no submission has been made.
         """
-        cid = hash_to_cid(self._competition.getSubmission(challenge_number, self._address))
-        if cid == CFG['NULL_IPFS_CID']:
+        cid = tools.hash_to_cid(self._competition.getSubmission(challenge_number, self._address))
+        if cid == tools.CFG['NULL_IPFS_CID']:
             return None
         return cid
 
@@ -90,8 +102,8 @@ class Submitter:
         if challenge_number is None:
             challenge_number = self._competition.getLatestChallengeNumber()
         dataset_hash = self._competition.getDatasetHash(challenge_number).hex()
-        dataset_cid = hash_to_cid(dataset_hash)
-        if dataset_cid == CFG['NULL_IPFS_CID']:
+        dataset_cid = tools.hash_to_cid(dataset_hash)
+        if dataset_cid == tools.CFG['NULL_IPFS_CID']:
             assert False, 'Dataset for this challenge does not exist.'
         if destination_directory is None:
             destination_directory = '{}//..//{}//challenge_{}'.format(CURRENT_DIR, CFG['DATASET_DIRECTORY'], challenge_number)
@@ -99,12 +111,12 @@ class Submitter:
         destination_file = '{}//dataset.zip'.format(destination_directory)
         if verbose:
             print('Downloading dataset..')
-        dataset_path = retrieve_file(dataset_cid, destination_file)
+        dataset_path = tools.retrieve_file(dataset_cid, destination_file)
         if verbose:
             print('Dataset saved to {}'.format(dataset_path))
         return dataset_path
 
-    def stake_and_submit(self, amount: Decimal or float or int, file_name: str, gas_price_in_gwei=None, verbose=True) -> bool:
+    def stake_and_submit(self, amount: Decimal | float | int, file_name: str, gas_price_in_gwei=None, verbose=True) -> bool:
         """
         Submits a new prediction or updates an existing prediction along with a stake amount.
         @param amount: Amount to set stake to.
@@ -124,20 +136,24 @@ class Submitter:
         if verbose:
             print('Encrypting file.')
         public_key_hash = self._competition.getKeyHash(challenge_number)
-        public_key_content = retrieve_content(hash_to_cid(public_key_hash))
+        public_key_content = tools.retrieve_content(tools.hash_to_cid(public_key_hash))
         public_key = RSA.import_key(public_key_content)
-        submission_dir, symmetric_key = encrypt_csv(file_name, self._address,
+        submission_dir, symmetric_key = tools.encrypt_csv(file_name, self._address,
                                                     self._comp_params.submission_directory,
                                                     self._comp_params.encrypted_directory,
                                                     public_key)
         if verbose:
             print('Zipping encrypted file.')
-        zipped_submission = zip_file(submission_dir)
+        zipped_submission = tools.zip_file(submission_dir)
         if verbose:
             print('Uploading and recording on blockchain.')
-        cid = pin_file_to_ipfs(zipped_submission, self._jwt)
-        gas_price_in_wei = set_gas_price_in_gwei(gas_price_in_gwei)
-        self._token.stakeAndSubmit(self._competition.address, decimal_to_uint(amount), cid_to_hash(cid), gas_price_in_wei)
+        cid = tools.pin_file_to_ipfs(zipped_submission, self._jwt)
+        gas_price_in_wei = tools.set_gas_price_in_gwei(gas_price_in_gwei)
+        self._token.stakeAndSubmit(
+            self._competition.address,
+            tools.decimal_to_uint(amount),
+            tools.cid_to_hash(cid),
+            gas_price_in_wei)
 
         # Save symmetric key locally for verification.
         with open('{}//{}.bin'.format(self._comp_params.encrypted_directory, '{}_symmetric_key'.format(cid)), 'wb') as f:
@@ -159,7 +175,7 @@ class Submitter:
 
         if verbose:
             print('Withdrawing submission and stake.')
-        gas_price_in_wei = set_gas_price_in_gwei(gas_price_in_gwei)
+        gas_price_in_wei = tools.set_gas_price_in_gwei(gas_price_in_gwei)
         self._token.stakeAndSubmit(self._competition.address, 0, (0).to_bytes(32, "big"), gas_price_in_wei)
 
     def download_and_check(self, original_submission_file_name: str, keep_temp_files=False, verbose=True) -> bool:
@@ -178,16 +194,16 @@ class Submitter:
         unzipped = 'temp_{}'.format(cid)
         if verbose:
             print('Retrieving file.')
-        retrieve_file(cid, temp_zip)
+        tools.retrieve_file(cid, temp_zip)
         if verbose:
             print('File retrieved.')
-        unzip_dir(temp_zip, unzipped)
+        tools.unzip_dir(temp_zip, unzipped)
         if verbose:
             print('File unzipped.')
         symmetric_key_path = '{}//{}_symmetric_key.bin'.format(self._comp_params.encrypted_directory, cid)
         file_to_decrypt = '{}//encrypted_predictions.bin'.format(unzipped)
         decrypted_file_name = '{}//{}.csv'.format(unzipped, cid)
-        decrypt_file(file_to_decrypt, symmetric_key_path, decrypted_file_name)
+        tools.decrypt_file(file_to_decrypt, symmetric_key_path, decrypted_file_name)
         if verbose:
             print('File decrypted. Comparing files.')
         original = pd.read_csv('{}//{}'.format(self._comp_params.submission_directory, original_submission_file_name))

--- a/lib/submitter.py
+++ b/lib/submitter.py
@@ -21,6 +21,9 @@ class Submitter:
                 request_kwargs={'timeout': tools.CFG['W3_TIMEOUT']}
             )
         )
+        # disabling strict byte checking...
+        self._w3.strict_bytes_type_checking = False
+
         self._jwt = jwt
         self._address = self._w3.to_checksum_address(address)
         self._private_key = private_key

--- a/lib/submitter.py
+++ b/lib/submitter.py
@@ -28,7 +28,7 @@ class Submitter:
         if private_key is not None:
             self._controlling_account = self._w3.eth.account.from_key(self._private_key)
 
-            # Sanity check on con          rolling address.
+            # Sanity check on conrolling address.
             assert self._controlling_account.address == self._address, 'Private key does not match address {}.'.format(
                 self._address)
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+base58==2.1.1
+pyyaml==6.0.2
+requests==2.32.3
+web3==7.7.0
+pandas==2.2.3


### PR DESCRIPTION
this includes
- port to much more recent web3 version, which was blocking the python upgrade
- fix type hints in various places
- re-organize import statements
- avoid import * statements
- add requirements.txt
- other minor code cleanups

I've tested this change and was able to submit and verify in this week's competition.

Open question:
- Testing with the live competition only works on Mondays and creates gas costs. Is it possible to test this on testnet somehow?
- I've only tested stake_and_submit and download_and_check, the rest is hopefully working as well. (A small test suite would be nice)

possible next steps:
1. more code cleanup, more or less following Google's style guide for Python: https://google.github.io/styleguide/pyguide.html
2. (maybe) add some tests
3. turn the code into a pip installable library
4. push it to pypi
5. include functionality from the other repos, like data download