### PR TITLE
Task/make delegate module accessible

### DIFF
--- a/yiedl/__init__.py
+++ b/yiedl/__init__.py
@@ -1,6 +1,6 @@
 """Yiedl competition client"""
-from yiedl.submitter import Submitter
 from yiedl.delegate import Delegate
+from yiedl.submitter import Submitter
 
 
 __all__ = [


### PR DESCRIPTION
Make the `Delegate` module accessible when installing this library via PyPi.